### PR TITLE
Add basic implementation of v1.1 API routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# NMOS Connection Management API Implementation Changelog
+
+## 2.0.0
+- Add support for provisional API v1.1
+
+## 1.0.1
+- Release version with v1.0 API support

--- a/nmosconnection/abstractDevice.py
+++ b/nmosconnection/abstractDevice.py
@@ -176,5 +176,9 @@ class AbstractDevice:
     def getParamsSchema(self):
         pass
 
+    @abstractmethod
+    def getTransportType(self):
+        pass
+
 class StagedLockedException(Exception):
     pass

--- a/nmosconnection/nmosDriver.py
+++ b/nmosconnection/nmosDriver.py
@@ -37,7 +37,7 @@ from uuid import uuid4
 from sdpManager import SdpManager
 from sdpFactory import senderFileFactory
 from facadeWrapper import SimpleFacadeWrapper
-from api import SINGLE_ROOT, DEVICE_ROOT, QUERY_APIVERSION
+from api import DEVICE_ROOT, CONN_APIVERSIONS
 
 # Set this to change the port the API is presented on
 WS_PORT = 8858
@@ -131,7 +131,7 @@ class NmosDriverWebApi(WebAPI):
         else:
             self.senders.pop(uuid)
             self.delSender(uuid)
-            
+
     @route('/api/receivers/', methods=['GET', 'POST'])
     def _api_receivers(self):
         if request.method == 'GET':
@@ -167,9 +167,10 @@ class NmosDriverWebApi(WebAPI):
 
     def addControl(self):
         # Add a device level control to the connection management API
-        url = "http://{}{}".format(getLocalIP(), DEVICE_ROOT)
-        type = "urn:x-nmos:control:sr-ctrl/" + QUERY_APIVERSION
-        self.facade.addControl(self.deviceId, {"type": type, "href": url})
+        for api_version in CONN_APIVERSIONS:
+            url = "http://{}{}{}/".format(getLocalIP(), DEVICE_ROOT, api_version)
+            type = "urn:x-nmos:control:sr-ctrl/" + api_version
+            self.facade.addControl(self.deviceId, {"type": type, "href": url})
 
     def addSender(self, legs, rtcp, fec):
         senderId = str(uuid4())

--- a/nmosconnection/rtpReceiver.py
+++ b/nmosconnection/rtpReceiver.py
@@ -234,7 +234,7 @@ class RtpReceiver(AbstractDevice):
         return self.active['sender_id']
 
     def getTransportType(self):
-        return "urn:x-nmos:transport:rtp"
+        return "rtp"
 
     def _setTp(self, value, field, leg):
         q = [{}, {}]

--- a/nmosconnection/rtpReceiver.py
+++ b/nmosconnection/rtpReceiver.py
@@ -232,7 +232,10 @@ class RtpReceiver(AbstractDevice):
 
     def getActiveSenderID(self):
         return self.active['sender_id']
-    
+
+    def getTransportType(self):
+        return "urn:x-nmos:transport:rtp"
+
     def _setTp(self, value, field, leg):
         q = [{}, {}]
         q[leg][field] = value

--- a/nmosconnection/rtpSender.py
+++ b/nmosconnection/rtpSender.py
@@ -265,7 +265,7 @@ class RtpSender(AbstractDevice):
         return self.transportFile
 
     def getTransportType(self):
-        return "urn:x-nmos:transport:rtp"
+        return "rtp"
 
     def _setTp(self, value, field, leg):
         q = {__tp__: [{}, {}]}

--- a/nmosconnection/rtpSender.py
+++ b/nmosconnection/rtpSender.py
@@ -264,6 +264,9 @@ class RtpSender(AbstractDevice):
     def getActiveTransportFileURL(self):
         return self.transportFile
 
+    def getTransportType(self):
+        return "urn:x-nmos:transport:rtp"
+
     def _setTp(self, value, field, leg):
         q = {__tp__: [{}, {}]}
         q[__tp__][leg][field] = value

--- a/nmosconnection/service.py
+++ b/nmosconnection/service.py
@@ -62,7 +62,8 @@ class ConnectionManagementService:
         self.logger.writeDebug("Running on port: {}"
                                .format(self.httpServer.port))
 
-        self.facade.register_service("http://127.0.0.1:{}".format(self.httpServer.port), DEVICE_ROOT[1:])
+        self.facade.register_service("http://127.0.0.1:{}".format(self.httpServer.port),
+                                     "{}{}/".format(DEVICE_ROOT[1:], CONN_APIVERSIONS[-1]))
         try:
             from nmosconnectiondriver.httpIpstudioDriver import httpIpstudioDriver
             self.logger.writeInfo("Using ipstudio driver")

--- a/nmosconnection/service.py
+++ b/nmosconnection/service.py
@@ -23,7 +23,7 @@ import signal
 import gevent
 
 from nmoscommon.httpserver import HttpServer
-from api import ConnectionManagementAPI, QUERY_APINAME, QUERY_APIVERSION, DEVICE_ROOT
+from api import ConnectionManagementAPI, CONN_APINAME, CONN_APIVERSIONS, DEVICE_ROOT
 from nmosDriver import NmosDriver
 from constants import WS_PORT
 
@@ -36,7 +36,7 @@ class ConnectionManagementService:
         from nmoscommon.facade import Facade
         self.logger = Logger("conmanage")
         self.logger.writeWarning("Could not find ipppython facade")
-        self.facade = Facade("{}/{}".format(QUERY_APINAME, QUERY_APIVERSION),
+        self.facade = Facade("{}/{}".format(CONN_APINAME, CONN_APIVERSIONS[-1]),
                              address="ipc:///tmp/ips-nodefacade", logger=self.logger)
         self.logger.writeDebug("Running Connection Management Service")
         self.httpServer = HttpServer(ConnectionManagementAPI, WS_PORT,

--- a/nmosconnection/testActivation.py
+++ b/nmosconnection/testActivation.py
@@ -39,18 +39,18 @@ class MockApi():
 
     def unLock(self):
         self.locked = False
-    
+
 class MockTimer():
     """A mock timer"""
     def __init__(self):
         self.cancelled = False
-        
+
     def cancel(self):
         self.cancelled = True
 
 class TestActivatorModule(unittest.TestCase):
     """Test the Activator Module"""
-    
+
     def setUp(self):
         self.api = MockApi(self.mockApiCallback)
         self.dut = Activator([self.api])
@@ -214,7 +214,7 @@ class TestActivatorModule(unittest.TestCase):
         testFunc = self.dut._getCurrentTime
         expected = time.time()
         response = testFunc().to_utc()
-        actual = float(str(response[0]) + "." + str(response[1]))
+        actual = float(str(response[0]) + "." + str(response[1]).zfill(9))
         self.assertAlmostEqual(actual, expected, 0)
 
     def test_schedule_absolute(self):

--- a/nmosconnection/testRoutes.py
+++ b/nmosconnection/testRoutes.py
@@ -176,6 +176,9 @@ class MockSenderAPI():
     def unLock(self):
         self.locked = False
 
+    def getTransportType(self):
+        return "rtp"
+
 
 class TestRoutes(unittest.TestCase):
     """Test the routes class"""

--- a/nmosconnection/testRoutes.py
+++ b/nmosconnection/testRoutes.py
@@ -203,7 +203,7 @@ class TestRoutes(unittest.TestCase):
         cls.dut.addReceiver(cls.mockReceiver, cls.receiverUUID)
 
         cls.baseUrl = "http://127.0.0.1:" + str(SENDER_WS_PORT)
-        cls.deviceRoot = cls.baseUrl + '/' + DEVICE_ROOT + CONN_APIVERSION + '/'
+        cls.deviceRoot = cls.baseUrl + '/' + DEVICE_ROOT
         cls.senderRoot = cls.deviceRoot + "single/senders/" + cls.senderUUID
         cls.receiverRoot = cls.deviceRoot + "single/receivers/" + cls.receiverUUID
         cls.maxDiff = None
@@ -257,9 +257,9 @@ class TestRoutes(unittest.TestCase):
         self.assertEqual(expected, actual)
 
     def test_correct_version(self):
-        """Checks that the API is served as version 1.0"""
+        """Checks that the API is served as version 1.0 and 1.1"""
         r = requests.get(self.baseUrl + "/x-nmos/connection/", headers=HEADERS)
-        expected = ["v1.0/"]
+        expected = ["v1.0/", "v1.1/"]
         actual = json.loads(r.text)
         self.assertEqual(expected, actual)
 

--- a/nmosconnection/testRoutes.py
+++ b/nmosconnection/testRoutes.py
@@ -42,12 +42,12 @@ SENDER_EXAMPLES = [
     "v1.0-sender-patch-relative.json"
 ]
 
-QUERY_APINAMESPACE = "x-nmos"
-QUERY_APINAME = "connection"
-QUERY_APIVERSION = "v1.0"
+CONN_APINAMESPACE = "x-nmos"
+CONN_APINAME = "connection"
+CONN_APIVERSION = "v1.0"
 
 
-DEVICE_ROOT = QUERY_APINAMESPACE+'/'+QUERY_APINAME+'/'+QUERY_APIVERSION+'/'
+DEVICE_ROOT = CONN_APINAMESPACE+'/'+CONN_APINAME+'/'+CONN_APIVERSION+'/'
 
 __location__ = os.path.realpath(
     os.path.join(os.getcwd(), os.path.dirname(__file__)))
@@ -103,7 +103,7 @@ class MockSdpParser():
 
     def getLastRequest(self):
         return {"lastfile": "yes"}
-    
+
     def getStagedRequest(self):
         return {"stagedfile": "yes"}
 
@@ -147,8 +147,8 @@ class MockSenderAPI():
         self.senderId = id
 
     def setMasterEnable(self, state):
-        self.masterEnable = state    
-    
+        self.masterEnable = state
+
     def getConstraints(self):
         return json.dumps({'constraints': 'constraints'})
 
@@ -203,7 +203,7 @@ class TestRoutes(unittest.TestCase):
         cls.dut.addReceiver(cls.mockReceiver, cls.receiverUUID)
 
         cls.baseUrl = "http://127.0.0.1:" + str(SENDER_WS_PORT)
-        cls.deviceRoot = cls.baseUrl + '/' + DEVICE_ROOT
+        cls.deviceRoot = cls.baseUrl + '/' + DEVICE_ROOT + CONN_APIVERSION + '/'
         cls.senderRoot = cls.deviceRoot + "single/senders/" + cls.senderUUID
         cls.receiverRoot = cls.deviceRoot + "single/receivers/" + cls.receiverUUID
         cls.maxDiff = None
@@ -464,7 +464,7 @@ class TestRoutes(unittest.TestCase):
                            headers=HEADERS, data=json.dumps(data))
         self.assertTrue(self.activator.updated)
         self.assertEqual(r.status_code, 200)
-        
+
     """Tests for /active"""
 
     def test_active_file_get(self):

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 ]
 
 setup(name="connectionmanagement",
-      version="1.0.1",
+      version="2.0.0",
       description="Connection Management API implementation",
       url='https://github.com/bbc/nmos-device-connection-management-ri/',
       author='BBC R&D',


### PR DESCRIPTION
A starting point for a v1.1-dev implementation. Will require a major version bump given the modification to QUERY_ defines.