### PR TITLE
service: add missing gevent monkey patch as service starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Connection Management API Implementation Changelog
 
+## 2.0.1
+- Add missing monkey patch call for gevent, potentially causing freezes
+
 ## 2.0.0
 - Add support for provisional API v1.1
 

--- a/nmosconnection/service.py
+++ b/nmosconnection/service.py
@@ -19,8 +19,12 @@ Starts an instance of the HTTP server and loads the API into it.
 Manages a graceful shutdown on SIGINT, SIGTERM
 """
 
-import signal
+
 import gevent
+from gevent import monkey
+monkey.patch_all()
+
+import signal
 
 from nmoscommon.httpserver import HttpServer
 from api import ConnectionManagementAPI, CONN_APINAME, CONN_APIVERSIONS, DEVICE_ROOT

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ packages_required = [
 ]
 
 setup(name="connectionmanagement",
-      version="2.0.0",
+      version="2.0.1",
       description="Connection Management API implementation",
       url='https://github.com/bbc/nmos-device-connection-management-ri/',
       author='BBC R&D',


### PR DESCRIPTION
I suspect the fact this is missing may be causing some issues when multiple requests come in at once. Will merge subject to confirmation it solves this problem.