### PR TITLE
sender: add method to get current receiver ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # NMOS Connection Management API Implementation Changelog
 
+## 2.2.0
+- Add mechanism to access Sender's receiver_id from driver
+
 ## 2.1.5
 - Move NMOS packages from recommends to depends
 

--- a/nmosconnection/rtpSender.py
+++ b/nmosconnection/rtpSender.py
@@ -270,6 +270,9 @@ class RtpSender(AbstractDevice):
     def getActiveTransportFileURL(self):
         return self.transportFile
 
+    def getActiveReceiverID(self):
+        return self.active['receiver_id']
+
     def getTransportType(self):
         return "rtp"
 

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ packages_required = [
 
 setup(
     name="connectionmanagement",
-    version="2.1.5",
+    version="2.2.0",
     description="Connection Management API implementation",
     url='https://github.com/bbc/nmos-device-connection-management-ri/',
     author='BBC R&D',


### PR DESCRIPTION
Matches the mechanism to get the sender_id in a Receiver.